### PR TITLE
Fix tagless editable agent installs

### DIFF
--- a/apps/material_agent/pyproject.toml
+++ b/apps/material_agent/pyproject.toml
@@ -17,6 +17,7 @@ enable = true
 vcs = "git"
 pattern = "default-unprefixed"
 fallback-version = "0.3.10"
+from-file = { source = "../../VERSION.md" }
 
 [tool.hatch.version]
 source = "uv-dynamic-versioning"

--- a/apps/material_agent_service/pyproject.toml
+++ b/apps/material_agent_service/pyproject.toml
@@ -75,6 +75,7 @@ enable = true
 vcs = "git"
 pattern = "default-unprefixed"
 fallback-version = "0.3.10"
+from-file = { source = "../../VERSION.md" }
 
 [tool.hatch.version]
 source = "uv-dynamic-versioning"

--- a/apps/physics_agent/pyproject.toml
+++ b/apps/physics_agent/pyproject.toml
@@ -17,6 +17,7 @@ enable = true
 vcs = "git"
 pattern = "default-unprefixed"
 fallback-version = "0.3.10"
+from-file = { source = "../../VERSION.md" }
 
 [tool.hatch.version]
 source = "uv-dynamic-versioning"

--- a/apps/physics_agent_service/pyproject.toml
+++ b/apps/physics_agent_service/pyproject.toml
@@ -70,6 +70,7 @@ enable = true
 vcs = "git"
 pattern = "default-unprefixed"
 fallback-version = "0.3.10"
+from-file = { source = "../../VERSION.md" }
 
 [tool.hatch.version]
 source = "uv-dynamic-versioning"

--- a/apps/texture_agent/pyproject.toml
+++ b/apps/texture_agent/pyproject.toml
@@ -20,6 +20,7 @@ enable = true
 vcs = "git"
 pattern = "default-unprefixed"
 fallback-version = "0.3.10"
+from-file = { source = "../../VERSION.md" }
 
 [tool.hatch.version]
 source = "uv-dynamic-versioning"

--- a/apps/texture_agent_service/pyproject.toml
+++ b/apps/texture_agent_service/pyproject.toml
@@ -69,6 +69,7 @@ enable = true
 vcs = "git"
 pattern = "default-unprefixed"
 fallback-version = "0.3.10"
+from-file = { source = "../../VERSION.md" }
 
 [tool.hatch.version]
 source = "uv-dynamic-versioning"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ enable = true
 vcs = "git"
 pattern = "default-unprefixed"
 fallback-version = "0.3.10"
+from-file = { source = "VERSION.md" }
 
 [tool.hatch.version]
 source = "uv-dynamic-versioning"

--- a/tests/test_pyproject_fallback_version.py
+++ b/tests/test_pyproject_fallback_version.py
@@ -2,17 +2,24 @@
 # SPDX-License-Identifier: Apache-2.0
 """Regression test for nvbug-6122035 / OMPE-91525.
 
-When users `unzip` a public source archive (no `.git`), `uv-dynamic-versioning`
-aborts with `RuntimeError: This does not appear to be a Git project` unless
-each `pyproject.toml` declares a `fallback-version`. Test pins both:
+When users `git clone` the public repository without tags, `uv-dynamic-versioning`
+reports a synthetic `0.0.0.post...` version. That is below the app dependency
+floors such as `world-understanding>=0.2.0`, so chained editable installs fail
+unless each dynamic package reads the repository version from `VERSION.md`.
 
-1. Every `pyproject.toml` in the repo declares `[tool.uv-dynamic-versioning].fallback-version`.
-2. The fallback equals `VERSION.md` — so a chained `uv pip install -e apps/<svc>`
+When users `unzip` a public source archive (no `.git`), `uv-dynamic-versioning`
+also needs a `fallback-version`. Test pins both:
+
+1. Every dynamic `pyproject.toml` reads `[tool.uv-dynamic-versioning].from-file`
+   from `VERSION.md`.
+2. Every dynamic `pyproject.toml` declares `[tool.uv-dynamic-versioning].fallback-version`.
+3. The fallback equals `VERSION.md` — so a chained `uv pip install -e apps/<svc>`
    still satisfies `world-understanding>=X.Y.Z` floors. The Codex round-2 review
    on !394 caught a `0.0.0` regression that would have broken those chained
    installs silently.
 """
 
+import os
 import tomllib
 from pathlib import Path
 
@@ -30,16 +37,30 @@ def _expected_version() -> str:
     return (REPO_ROOT / "VERSION.md").read_text(encoding="utf-8").strip()
 
 
+def _expected_version_source(pyproject_path: Path) -> str:
+    return os.path.relpath(REPO_ROOT / "VERSION.md", pyproject_path.parent).replace(
+        os.sep, "/"
+    )
+
+
 @pytest.mark.parametrize(
     "pyproject_path", PYPROJECT_PATHS, ids=lambda p: str(p.relative_to(REPO_ROOT))
 )
-def test_fallback_version_declared_and_matches_version_md(pyproject_path: Path) -> None:
+def test_dynamic_versioning_reads_version_md(pyproject_path: Path) -> None:
     data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
     udv = data.get("tool", {}).get("uv-dynamic-versioning")
     if udv is None:
         pytest.skip(
             f"{pyproject_path.relative_to(REPO_ROOT)} does not use uv-dynamic-versioning"
         )
+
+    expected_source = _expected_version_source(pyproject_path)
+    from_file = udv.get("from-file")
+    assert from_file == {"source": expected_source}, (
+        f"{pyproject_path.relative_to(REPO_ROOT)} must read its dynamic version "
+        f"from VERSION.md using source={expected_source!r}. Tagless Git clones "
+        "otherwise resolve to 0.0.0.post... and can fail dependency resolution."
+    )
 
     fallback = udv.get("fallback-version")
     assert fallback, (


### PR DESCRIPTION
## Summary

Fixes #3.

This makes every `uv-dynamic-versioning` package read the release version from `VERSION.md` via `from-file`, instead of deriving `0.0.0.post...` from a public Git clone with no tags. The existing `fallback-version` remains in place for source archive installs where Git metadata is unavailable.

## Validation

- `uv run --with pytest pytest -o addopts= tests/test_pyproject_fallback_version.py`
- Reproduced the original failure in a clean `NVIDIA-Omniverse/content-agents` clone.
- Verified the fix in a throwaway tagless Git repo: package versions report `0.3.10`, and `uv pip install --dry-run -e . -e apps/material_agent -e apps/physics_agent -e apps/texture_agent` resolves successfully.