### PR TITLE
Fix circular import in material_agent.api.builders

### DIFF
--- a/apps/material_agent/material_agent/api/builders.py
+++ b/apps/material_agent/material_agent/api/builders.py
@@ -19,7 +19,6 @@ from material_agent.api.defaults import (
     DEFAULT_VLM_MODEL,
     DEFAULT_VLM_TEMPERATURE,
 )
-from material_agent.config.schema import get_step_defaults
 
 
 def build_vlm_config(
@@ -327,6 +326,8 @@ def build_unified_pipeline_config(
         "vector_store",
         "predictions_path",
     }
+
+    from material_agent.config.schema import get_step_defaults
 
     for step_name in enabled_steps:
         step_defaults = get_step_defaults(step_name)


### PR DESCRIPTION
config/schema.py imports from api.defaults, which forces api/__init__.py to run and pull in builders.py. builders.py then tries to import get_step_defaults from config/schema
result: material-agent run crashes with ImportError before the pipeline starts.

Moved the get_step_defaults import inside build_unified_pipeline_config, the only function that uses it. Closes #4.

Reproduced and verified on Ubuntu 24.04 / Python 3.12.3 against
`apps/material_agent/configs/unified_example.yaml`.