### PR TITLE
Add agent-readiness CI scan for shift-left validation

### DIFF
--- a/.github/workflows/agent-readiness.yml
+++ b/.github/workflows/agent-readiness.yml
@@ -1,0 +1,98 @@
+name: Agent Readiness
+
+# Shift-left agent-readiness CI for NVIDIA-Omniverse/content-agents.
+# Pattern source: https://github.com/NVIDIA-dev/product-skills/tree/main/tools/agent-readiness-ci
+#
+# Triggers:
+#   - pull_request: runs on every PR against any branch (this is the demo signal).
+#   - workflow_dispatch: lets a maintainer trigger a run manually from the Actions tab.
+# Intentionally NOT triggered on push to main: this PR is establishing the pattern;
+# enabling the main-branch scan is a follow-up after the team has reviewed the signal.
+#
+# Safety posture:
+#   - permissions: contents: read  (CI cannot write to the repo)
+#   - No secrets read or written
+#   - Observability-only: --fail-on-threshold is not passed, so the gate cannot block a PR
+#   - Runs on the NVIDIA-Omniverse omni-ops self-hosted CPU runner pool
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  agent-readiness-scan:
+    name: agent-readiness scan
+    runs-on: [self-hosted, omni-ops, cpu]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install runner dependencies
+        run: python -m pip install pyyaml
+
+      - name: Validate readiness config
+        env:
+          PYTHONPATH: tools/agent-readiness-ci
+        run: python -m agent_readiness.cli validate-config agent-readiness.yaml
+
+      - name: Run static lane
+        env:
+          PYTHONPATH: tools/agent-readiness-ci
+        run: python -m agent_readiness.cli run --lane static --config agent-readiness.yaml --out agent-readiness-runs
+
+      - name: Run api-design lane
+        env:
+          PYTHONPATH: tools/agent-readiness-ci
+        run: python -m agent_readiness.cli run --lane api-design --config agent-readiness.yaml --out agent-readiness-runs
+
+      - name: Run headless lane (dry-run)
+        env:
+          PYTHONPATH: tools/agent-readiness-ci
+        run: python -m agent_readiness.cli run --lane headless --agent dry-run --config agent-readiness.yaml --out agent-readiness-runs
+
+      - name: Summarize
+        env:
+          PYTHONPATH: tools/agent-readiness-ci
+        run: python -m agent_readiness.cli summarize --config agent-readiness.yaml --out agent-readiness-runs
+
+      - name: Write GitHub Step Summary
+        if: always()
+        run: |
+          RUN_DIR="agent-readiness-runs/content-agents/latest"
+          echo "## Agent Readiness Summary" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f "$RUN_DIR/ci-summary.json" ]; then
+            python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json, pathlib
+          d = json.loads(pathlib.Path("agent-readiness-runs/content-agents/latest/ci-summary.json").read_text())
+          print(f"- status: **{d['status']}**")
+          print(f"- P0 jobs declared: {d['p0_jobs']}")
+          print(f"- P0 live passes: {d['p0_live_passes']}")
+          print(f"- P0 live pass rate: {d['p0_live_pass_rate']}")
+          print(f"- API design score: {d['api_design_score']}")
+          fails = d.get('failures') or ['none']
+          print(f"- failures: {', '.join(fails)}")
+          PY
+          fi
+          if [ -f "$RUN_DIR/static-readiness.md" ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            cat "$RUN_DIR/static-readiness.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ -f "$RUN_DIR/api-design-readiness.md" ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            cat "$RUN_DIR/api-design-readiness.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload readiness artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-readiness-runs
+          path: agent-readiness-runs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Agent-readiness CI runtime artifacts (per-PR runs and published dashboards).
+agent-readiness-runs/
+public/

--- a/agent-readiness.yaml
+++ b/agent-readiness.yaml
@@ -1,0 +1,110 @@
+product_id: content-agents
+name: NVIDIA Content Agents
+repo_path: .
+
+docs:
+  primary_url: https://github.com/NVIDIA-Omniverse/content-agents
+  repo: https://github.com/NVIDIA-Omniverse/content-agents.git
+
+prerequisites:
+  env_vars:
+    - name: NVIDIA_API_KEY
+      required: true
+      where_to_get: https://build.nvidia.com/
+    - name: OPENAI_API_KEY
+      required: false
+      where_to_get: https://platform.openai.com/api-keys
+    - name: ANTHROPIC_API_KEY
+      required: false
+      where_to_get: https://console.anthropic.com/settings/keys
+    - name: GOOGLE_API_KEY
+      required: false
+      where_to_get: https://aistudio.google.com/apikey
+  hardware:
+    gpu_required: true
+    gpu_min_vram_gb: 48
+    notes: >-
+      Material and Physics agents require an RTX-capable NVIDIA GPU with 48 GB
+      VRAM (e.g. L40, L40S, RTX PRO 6000) plus the NVIDIA Container Toolkit and
+      Docker Compose v2.24+. Validation Agent hello-world is CPU-only and does
+      not require a GPU or a VLM key.
+
+jobs:
+  - id: JOB-CONTENT-AGENTS-MATERIAL-HELLO
+    priority: P0
+    title: Material Agent hello-world via documented CLI
+    success_criteria:
+      - Installs the material-agent CLI using only the documented uv path.
+      - Loads apps/material_agent/configs/unified_example.yaml without edits.
+      - Runs material-agent run on the unified example and produces a
+        materialized USD output with a verdict.
+      - Requires no evaluator-written glue beyond what README and AGENTS.md
+        instruct.
+
+  - id: JOB-CONTENT-AGENTS-MATERIAL-BYO
+    priority: P0
+    title: Bring-your-own USD asset into the Material Agent pipeline
+    success_criteria:
+      - Copies apps/material_agent/configs/unified_example.yaml to a new file.
+      - Edits input.usd_path and input.reference_images for a supplied USD asset
+        using absolute paths.
+      - Runs material-agent run on the new config and produces a materialized
+        USD output.
+      - Surfaces any documented prerequisite (driver, render backend, API key)
+        as an actionable missing-prerequisite message.
+
+  - id: JOB-CONTENT-AGENTS-MATERIAL-SERVICE-SMOKE
+    priority: P0
+    title: Material Agent REST service smoke via Docker Compose
+    success_criteria:
+      - Brings up apps/material_agent_service/docker-compose.yml with the
+        documented --env-file .env flag.
+      - GET /health on the service returns a healthy response within the
+        documented warm-up window.
+      - The included Python client in apps/material_agent_service/client/
+        successfully drives the service with the documented example payload.
+
+  - id: JOB-CONTENT-AGENTS-VALIDATION-HELLO
+    priority: P1
+    title: Validation Agent hello-world on checked-in behavior evidence
+    success_criteria:
+      - Installs the validation-agent CLI.
+      - Runs validation-agent run on
+        apps/validation_agent/examples/configs/steel_scaffold_behavior_refine_summary.yaml.
+      - Produces validation_request.json, validation_plan.json, and
+        validation_result.json without requiring a GPU or a VLM key.
+
+  - id: JOB-CONTENT-AGENTS-MISSING-KEY-RECOVERY
+    priority: P1
+    title: Recover from a missing VLM API key
+    success_criteria:
+      - Running a material-agent or physics-agent hello-world without an API
+        key fails with a clear, actionable message naming the missing variable
+        (e.g. NVIDIA_API_KEY).
+      - The message references the documented setup path (.env_example, README
+        Supported VLM Backends).
+      - No secrets are printed in logs or error messages.
+
+modes:
+  static: true
+  api_design: true
+  headless_agents: [dry-run]
+  remote_deployment:
+    enabled: false
+    notes: >-
+      Enable when a GPU runner (Pathfinder, Brev, or self-hosted) is available
+      for the Material / Physics / Texture P0 jobs.
+  litmus_vdr:
+    enabled: false
+  fvr_rc:
+    enabled: false
+
+thresholds:
+  # First-PR posture: observability-only. The PR workflow does not pass
+  # --fail-on-threshold, so the gate never blocks while the team gets used to
+  # the signal. Tighten these once a real headless or remote adapter lands and
+  # P0 jobs can actually execute live in CI.
+  p0_live_pass_rate_min: 0.0
+  api_design_score_min: 0.5
+  fail_on_p0_fail: false
+  fail_on_unverified_blockers: false

--- a/tools/agent-readiness-ci/agent_readiness/__init__.py
+++ b/tools/agent-readiness-ci/agent_readiness/__init__.py
@@ -1,0 +1,3 @@
+"""Unified agent readiness CI toolkit."""
+
+__version__ = "0.1.0"

--- a/tools/agent-readiness-ci/agent_readiness/api_design.py
+++ b/tools/agent-readiness-ci/agent_readiness/api_design.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .artifacts import write_json, write_text
+from .config import ReadinessConfig
+
+
+MAX_FILE_BYTES = 512_000
+MAX_CANDIDATE_FILES = 500
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="ignore")[:MAX_FILE_BYTES]
+
+
+def _rel(repo: Path, path: Path) -> str:
+    return path.relative_to(repo).as_posix()
+
+
+def _candidate_files(repo: Path) -> list[Path]:
+    exact_names = {
+        "README.md",
+        "AGENTS.md",
+        "CLAUDE.md",
+        "llms.txt",
+        "llms-full.txt",
+        "openapi.yaml",
+        "openapi.yml",
+        "openapi.json",
+        "swagger.yaml",
+        "swagger.yml",
+        "swagger.json",
+        "schema.graphql",
+        "package.json",
+        "pyproject.toml",
+    }
+    suffixes = {".md", ".yaml", ".yml", ".json", ".graphql", ".proto"}
+    files: set[Path] = set()
+    for name in exact_names:
+        path = repo / name
+        if path.is_file():
+            files.add(path)
+    for root_name in ("docs", "api", "apis", "openapi", "schema", "schemas"):
+        root = repo / root_name
+        if not root.exists():
+            continue
+        for path in root.rglob("*"):
+            if path.is_file() and path.suffix.lower() in suffixes:
+                files.add(path)
+    for pattern in (
+        "**/openapi*.yaml",
+        "**/openapi*.yml",
+        "**/openapi*.json",
+        "**/swagger*.yaml",
+        "**/swagger*.yml",
+        "**/swagger*.json",
+        "**/*api*.md",
+        "**/*.graphql",
+        "**/*.proto",
+        "**/mcp*.json",
+    ):
+        for path in repo.glob(pattern):
+            if _is_reasonable_candidate(repo, path):
+                files.add(path)
+    return sorted(files, key=lambda item: item.as_posix())[:MAX_CANDIDATE_FILES]
+
+
+def _is_reasonable_candidate(repo: Path, path: Path) -> bool:
+    if not path.is_file():
+        return False
+    rel = _rel(repo, path)
+    blocked_parts = {
+        ".git",
+        ".venv",
+        "node_modules",
+        "__pycache__",
+        ".pytest_cache",
+        "dist",
+        "build",
+    }
+    if set(Path(rel).parts) & blocked_parts:
+        return False
+    return path.suffix.lower() in {".md", ".yaml", ".yml", ".json", ".graphql", ".proto"}
+
+
+def _build_corpus(repo: Path) -> list[tuple[Path, str, str]]:
+    corpus: list[tuple[Path, str, str]] = []
+    for path in _candidate_files(repo):
+        text = _read_text(path)
+        corpus.append((path, _rel(repo, path), text))
+    return corpus
+
+
+def _matching_paths(corpus: list[tuple[Path, str, str]], terms: list[str]) -> list[str]:
+    matches: list[str] = []
+    for _, rel, text in corpus:
+        lower = text.lower()
+        if any(term.lower() in lower for term in terms):
+            matches.append(rel)
+    return sorted(set(matches))
+
+
+def _count_terms(corpus: list[tuple[Path, str, str]], terms: list[str]) -> int:
+    combined = "\n".join(text.lower() for _, _, text in corpus)
+    return sum(1 for term in terms if term.lower() in combined)
+
+
+def _exists_path(repo: Path, names: list[str]) -> list[str]:
+    return [name for name in names if (repo / name).exists()]
+
+
+def _criterion(
+    category: str,
+    status: str,
+    summary: str,
+    evidence: list[str],
+    recommendation: str,
+    blocker: bool = False,
+) -> dict:
+    if status == "Pass":
+        severity = "none"
+        points = 10
+    elif status == "Partial":
+        severity = "minor"
+        points = 5
+    else:
+        severity = "major" if blocker else "minor"
+        points = 0
+    return {
+        "category": category,
+        "status": status,
+        "method": "Static API Design",
+        "severity": severity,
+        "blocker": blocker and status == "Fail",
+        "points": points,
+        "max_points": 10,
+        "summary": summary,
+        "evidence": evidence,
+        "recommendation": recommendation,
+    }
+
+
+def scan_api_design(config: ReadinessConfig) -> dict:
+    repo = config.repo_path
+    corpus = _build_corpus(repo)
+    checks: list[dict] = []
+
+    contract_files = _matching_paths(
+        corpus,
+        ["openapi:", '"openapi"', "swagger", "schema.graphql", "type Query", "mcpServers", "tools/list"],
+    )
+    contract_fallback = _exists_path(repo, ["api", "apis", "docs/api.md", "pyproject.toml", "package.json"])
+    if contract_files:
+        contract_status = "Pass"
+        contract_summary = "Machine-readable API/tool contracts are discoverable."
+        contract_evidence = contract_files
+    elif contract_fallback:
+        contract_status = "Partial"
+        contract_summary = "API surface exists, but a machine-readable contract was not found."
+        contract_evidence = contract_fallback
+    else:
+        contract_status = "Fail"
+        contract_summary = "No machine-readable API, GraphQL, MCP, SDK, or CLI contract was found."
+        contract_evidence = []
+    checks.append(
+        _criterion(
+            "machine_readable_contract",
+            contract_status,
+            contract_summary,
+            contract_evidence,
+            "Publish OpenAPI/GraphQL/MCP schemas, typed SDK contracts, or CLI command schemas in a stable path.",
+            blocker=True,
+        )
+    )
+
+    task_terms = [
+        "operationid",
+        "create",
+        "start",
+        "run",
+        "submit",
+        "validate",
+        "deploy",
+        "provision",
+        "migrate",
+        "publish",
+        "session",
+        "job",
+        "workflow",
+    ]
+    task_count = _count_terms(corpus, task_terms)
+    checks.append(
+        _criterion(
+            "task_shaped_operations",
+            "Pass" if task_count >= 5 else ("Partial" if task_count >= 2 else "Fail"),
+            "API operations appear task-shaped." if task_count >= 5 else "API operations may be too low-level or under-documented.",
+            _matching_paths(corpus, task_terms),
+            "Expose task-level operations such as validate, deploy, run, submit, create job, cancel, and resume.",
+        )
+    )
+
+    safety_terms = ["dry_run", "dry run", "preview", "sandbox", "test mode", "idempotency", "idempotent", "rollback", "cancel"]
+    safety_count = _count_terms(corpus, safety_terms)
+    checks.append(
+        _criterion(
+            "safe_execution_modes",
+            "Pass" if safety_count >= 3 else ("Partial" if safety_count >= 1 else "Fail"),
+            "Safe execution controls are documented." if safety_count >= 3 else "Safe execution controls are incomplete.",
+            _matching_paths(corpus, safety_terms),
+            "Add dry-run/preview, sandbox or test mode, idempotency keys, cancel, rollback, and production-safety guidance.",
+            blocker=True,
+        )
+    )
+
+    error_terms = ["error_code", "error code", "status code", "retryable", "remediation", "troubleshoot", "docs link", "400", "401", "403", "429"]
+    error_count = _count_terms(corpus, error_terms)
+    checks.append(
+        _criterion(
+            "structured_error_recovery",
+            "Pass" if error_count >= 3 else ("Partial" if error_count >= 1 else "Fail"),
+            "Structured error and remediation guidance is present." if error_count >= 3 else "Error recovery is not structured enough for agents.",
+            _matching_paths(corpus, error_terms),
+            "Return stable error codes, retryability, field-level validation, missing permission/env names, and remediation links.",
+            blocker=True,
+        )
+    )
+
+    auth_terms = ["oauth", "scope", "scopes", "token", "api key", "permission", "permissions", "least privilege", "actor", "service account"]
+    auth_count = _count_terms(corpus, auth_terms)
+    checks.append(
+        _criterion(
+            "scoped_auth_and_permissions",
+            "Pass" if auth_count >= 3 else ("Partial" if auth_count >= 1 else "Fail"),
+            "Authentication and permission boundaries are documented." if auth_count >= 3 else "Auth scopes and permission behavior are underspecified.",
+            _matching_paths(corpus, auth_terms),
+            "Document scoped credentials, app/user identity, least privilege scopes, and explicit permission failure behavior.",
+            blocker=True,
+        )
+    )
+
+    async_terms = ["job", "session", "status", "progress", "logs", "artifacts", "cancel", "resume", "webhook", "event", "events"]
+    async_count = _count_terms(corpus, async_terms)
+    checks.append(
+        _criterion(
+            "long_running_operation_model",
+            "Pass" if async_count >= 4 else ("Partial" if async_count >= 2 else "Fail"),
+            "Long-running operation state is documented." if async_count >= 4 else "Long-running operation semantics are incomplete.",
+            _matching_paths(corpus, async_terms),
+            "Represent async work as jobs/sessions with status, progress, logs, artifacts, cancel/resume, and events/webhooks.",
+        )
+    )
+
+    example_paths = _matching_paths(corpus, ["```", "request:", "response:", "curl ", "example", "examples:"])
+    request_response_count = _count_terms(corpus, ["request:", "response:", "curl ", "examples:"])
+    has_code_block = bool(_matching_paths(corpus, ["```"]))
+    checks.append(
+        _criterion(
+            "deterministic_examples",
+            "Pass" if has_code_block and request_response_count >= 2 else ("Partial" if has_code_block or request_response_count else "Fail"),
+            "Request/response examples are available." if has_code_block and request_response_count >= 2 else "API examples are not deterministic enough.",
+            example_paths,
+            "Provide copy-paste request and response examples that run in sandbox/test mode with expected outputs.",
+        )
+    )
+
+    observability_terms = ["request_id", "request id", "trace_id", "trace id", "audit", "logs", "artifact", "artifacts", "telemetry", "event"]
+    observability_count = _count_terms(corpus, observability_terms)
+    checks.append(
+        _criterion(
+            "observable_outputs",
+            "Pass" if observability_count >= 3 else ("Partial" if observability_count >= 1 else "Fail"),
+            "API outputs expose useful operational evidence." if observability_count >= 3 else "API outputs lack observable evidence for agents.",
+            _matching_paths(corpus, observability_terms),
+            "Return request IDs, trace IDs, audit records, logs, events, and artifact URLs so CI can prove what happened.",
+        )
+    )
+
+    version_terms = ["api version", "version:", '"version"', "changelog", "deprecat", "/v1", "/v2"]
+    version_count = _count_terms(corpus, version_terms)
+    checks.append(
+        _criterion(
+            "versioning_and_compatibility",
+            "Pass" if version_count >= 1 else "Partial",
+            "Versioning or compatibility signals are present." if version_count >= 1 else "Versioning behavior is not explicit.",
+            _matching_paths(corpus, version_terms),
+            "Document API versions, deprecation policy, changelog behavior, and backwards-compatibility expectations.",
+        )
+    )
+
+    tool_terms = ["mcp", "cli", "sdk", "client", "openapi", "graphql", "llms.txt", "agent"]
+    tool_count = _count_terms(corpus, tool_terms)
+    checks.append(
+        _criterion(
+            "agent_tool_surface_parity",
+            "Pass" if tool_count >= 4 else ("Partial" if tool_count >= 2 else "Fail"),
+            "Agent-facing tool surfaces are visible." if tool_count >= 4 else "Tool-surface parity across API/CLI/SDK/MCP is unclear.",
+            _matching_paths(corpus, tool_terms),
+            "Keep API, CLI, SDK, MCP, and docs concepts aligned with matching operation names and examples.",
+        )
+    )
+
+    points = sum(item["points"] for item in checks)
+    max_points = sum(item["max_points"] for item in checks)
+    blockers = [item["category"] for item in checks if item["blocker"]]
+    return {
+        "product_id": config.product_id,
+        "name": config.name,
+        "lane": "api-design",
+        "checks": checks,
+        "score": {
+            "points": points,
+            "max_points": max_points,
+            "ratio": round(points / max_points, 4) if max_points else 0.0,
+        },
+        "totals": {
+            "pass": sum(1 for item in checks if item["status"] == "Pass"),
+            "partial": sum(1 for item in checks if item["status"] == "Partial"),
+            "fail": sum(1 for item in checks if item["status"] == "Fail"),
+        },
+        "blockers": blockers,
+        "candidate_files": [rel for _, rel, _ in corpus],
+    }
+
+
+def write_api_design_artifacts(run_path: Path, payload: dict) -> None:
+    write_json(run_path / "api-design-readiness.json", payload)
+    lines = [
+        f"# API Design Readiness - {payload['name']}",
+        "",
+        f"Score: {payload['score']['points']}/{payload['score']['max_points']} ({payload['score']['ratio']:.2f})",
+        "",
+        "| Category | Status | Evidence | Recommendation |",
+        "|---|---|---|---|",
+    ]
+    for item in payload["checks"]:
+        evidence = ", ".join(item["evidence"]) if item["evidence"] else "none"
+        lines.append(f"| {item['category']} | {item['status']} | {evidence} | {item['recommendation']} |")
+    if payload["blockers"]:
+        lines.extend(["", "## Blocking Gaps", ""])
+        for blocker in payload["blockers"]:
+            lines.append(f"- {blocker}")
+    lines.append("")
+    write_text(run_path / "api-design-readiness.md", "\n".join(lines))

--- a/tools/agent-readiness-ci/agent_readiness/artifacts.py
+++ b/tools/agent-readiness-ci/agent_readiness/artifacts.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .config import ReadinessConfig
+
+
+def run_dir(out: Path, config: ReadinessConfig) -> Path:
+    path = out / config.product_id / "latest"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")

--- a/tools/agent-readiness-ci/agent_readiness/cli.py
+++ b/tools/agent-readiness-ci/agent_readiness/cli.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from .api_design import scan_api_design, write_api_design_artifacts
+from .artifacts import run_dir
+from .config import ConfigError, load_config
+from .headless import run_dry
+from .optional_lanes import run_fvr_placeholder, run_hosted_litmus_placeholder, run_remote_placeholder
+from .publish import publish as publish_site
+from .static_scan import scan, write_static_artifacts
+from .summary import summarize as summarize_run
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="agent-readiness")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    validate = sub.add_parser("validate-config", help="Validate agent-readiness.yaml")
+    validate.add_argument("config", type=Path)
+
+    run = sub.add_parser("run", help="Run one readiness lane")
+    run.add_argument("--lane", required=True, choices=["static", "api-design", "headless", "remote", "hosted-litmus", "fvr-rc"])
+    run.add_argument("--config", type=Path, default=Path("agent-readiness.yaml"))
+    run.add_argument("--out", type=Path, default=Path("agent-readiness-runs"))
+    run.add_argument("--agent", default="dry-run")
+
+    summarize = sub.add_parser("summarize", help="Create ci-summary.json")
+    summarize.add_argument("--config", type=Path, default=Path("agent-readiness.yaml"))
+    summarize.add_argument("--out", type=Path, default=Path("agent-readiness-runs"))
+    summarize.add_argument("--fail-on-threshold", action="store_true")
+
+    publish = sub.add_parser("publish", help="Publish a minimal static dashboard")
+    publish.add_argument("--config", type=Path, default=Path("agent-readiness.yaml"))
+    publish.add_argument("--runs", type=Path, default=Path("agent-readiness-runs"))
+    publish.add_argument("--out", type=Path, default=Path("public"))
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "validate-config":
+            config = load_config(args.config)
+            print(f"OK: {config.product_id} ({len(config.jobs)} job(s))")
+            return 0
+
+        if args.command == "run":
+            config = load_config(args.config)
+            path = run_dir(args.out, config)
+            if args.lane == "static":
+                payload = scan(config)
+                write_static_artifacts(path, payload)
+                print(f"wrote {path / 'static-readiness.json'}")
+                return 0
+            if args.lane == "api-design":
+                payload = scan_api_design(config)
+                write_api_design_artifacts(path, payload)
+                print(f"wrote {path / 'api-design-readiness.json'}")
+                return 0
+            if args.lane == "headless":
+                if args.agent != "dry-run":
+                    raise ConfigError("only --agent dry-run is implemented in this local toolkit version")
+                run_dry(config, path, args.agent)
+                print(f"wrote {path / 'scorecard.json'}")
+                return 0
+            if args.lane == "remote":
+                run_remote_placeholder(config, path)
+                print(f"wrote {path / 'remote' / 'remote-result.json'}")
+                return 0
+            if args.lane == "hosted-litmus":
+                run_hosted_litmus_placeholder(config, path)
+                print(f"wrote {path / 'hosted' / 'litmus-run.json'}")
+                return 0
+            if args.lane == "fvr-rc":
+                run_fvr_placeholder(config, path)
+                print(f"wrote {path / 'fvr' / 'fvr-summary.json'}")
+                return 0
+
+        if args.command == "summarize":
+            config = load_config(args.config)
+            payload = summarize_run(config, run_dir(args.out, config))
+            print(f"{payload['status']}: P0 live pass rate {payload['p0_live_pass_rate']:.2f}")
+            if args.fail_on_threshold and payload["status"] != "passed":
+                return 1
+            return 0
+
+        if args.command == "publish":
+            config = load_config(args.config)
+            publish_site(config, args.runs, args.out)
+            print(f"wrote {args.out / 'index.html'}")
+            return 0
+    except ConfigError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/agent-readiness-ci/agent_readiness/config.py
+++ b/tools/agent-readiness-ci/agent_readiness/config.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class ConfigError(ValueError):
+    """Raised when an agent-readiness config is invalid."""
+
+
+@dataclass
+class Job:
+    id: str
+    priority: str
+    title: str
+    success_criteria: list[str]
+
+
+@dataclass
+class Thresholds:
+    p0_live_pass_rate_min: float = 0.8
+    api_design_score_min: float = 0.7
+    fail_on_p0_fail: bool = True
+    fail_on_unverified_blockers: bool = True
+
+
+@dataclass
+class ReadinessConfig:
+    product_id: str
+    name: str
+    repo_path: Path
+    jobs: list[Job]
+    raw: dict[str, Any] = field(repr=False)
+    thresholds: Thresholds = field(default_factory=Thresholds)
+
+
+def _require_mapping(data: Any) -> dict[str, Any]:
+    if not isinstance(data, dict):
+        raise ConfigError("config must be a YAML mapping")
+    return data
+
+
+def _require_str(data: dict[str, Any], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ConfigError(f"required field '{key}' is missing or empty")
+    return value.strip()
+
+
+def _load_jobs(data: dict[str, Any]) -> list[Job]:
+    raw_jobs = data.get("jobs")
+    if not isinstance(raw_jobs, list) or not raw_jobs:
+        raise ConfigError("required field 'jobs' must contain at least one job")
+    jobs: list[Job] = []
+    seen_ids: set[str] = set()
+    for index, item in enumerate(raw_jobs, start=1):
+        if not isinstance(item, dict):
+            raise ConfigError(f"jobs[{index}] must be a mapping")
+        job_id = _require_str(item, "id")
+        if job_id in seen_ids:
+            raise ConfigError(f"duplicate job id '{job_id}'")
+        seen_ids.add(job_id)
+        priority = str(item.get("priority", "P0")).strip()
+        if priority not in {"P0", "P1", "P2"}:
+            raise ConfigError(f"job '{job_id}' has invalid priority '{priority}'")
+        title = _require_str(item, "title")
+        criteria = item.get("success_criteria")
+        if not isinstance(criteria, list) or not all(isinstance(c, str) and c.strip() for c in criteria):
+            raise ConfigError(f"job '{job_id}' must define non-empty success_criteria")
+        jobs.append(Job(id=job_id, priority=priority, title=title, success_criteria=[c.strip() for c in criteria]))
+    return jobs
+
+
+def _load_thresholds(data: dict[str, Any]) -> Thresholds:
+    raw = data.get("thresholds") or {}
+    if not isinstance(raw, dict):
+        raise ConfigError("thresholds must be a mapping when provided")
+    return Thresholds(
+        p0_live_pass_rate_min=float(raw.get("p0_live_pass_rate_min", 0.8)),
+        api_design_score_min=float(raw.get("api_design_score_min", 0.7)),
+        fail_on_p0_fail=bool(raw.get("fail_on_p0_fail", True)),
+        fail_on_unverified_blockers=bool(raw.get("fail_on_unverified_blockers", True)),
+    )
+
+
+def load_config(path: Path) -> ReadinessConfig:
+    try:
+        data = _require_mapping(yaml.safe_load(path.read_text(encoding="utf-8")) or {})
+    except FileNotFoundError as exc:
+        raise ConfigError(f"config not found: {path}") from exc
+    except yaml.YAMLError as exc:
+        raise ConfigError(f"invalid YAML in {path}: {exc}") from exc
+
+    product_id = _require_str(data, "product_id")
+    name = _require_str(data, "name")
+    repo_value = data.get("repo_path", ".")
+    if not isinstance(repo_value, str) or not repo_value.strip():
+        raise ConfigError("repo_path must be a path string when provided")
+    repo_path = Path(repo_value).expanduser()
+    if not repo_path.is_absolute():
+        repo_path = (path.parent / repo_path).resolve()
+    else:
+        repo_path = repo_path.resolve()
+    if not repo_path.exists():
+        raise ConfigError(f"repo_path does not exist: {repo_path}")
+
+    return ReadinessConfig(
+        product_id=product_id,
+        name=name,
+        repo_path=repo_path,
+        jobs=_load_jobs(data),
+        raw=data,
+        thresholds=_load_thresholds(data),
+    )

--- a/tools/agent-readiness-ci/agent_readiness/headless.py
+++ b/tools/agent-readiness-ci/agent_readiness/headless.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .artifacts import write_json, write_text
+from .config import ReadinessConfig, Job
+
+
+def _prompt_for(config: ReadinessConfig, jobs: list[Job]) -> str:
+    lines = [
+        f"You are evaluating agent readiness for {config.name}.",
+        f"Repository path: {config.repo_path}",
+        "",
+        "Attempt each job through shipped docs and product-supported surfaces.",
+        "Do not count evaluator-written glue as a full pass.",
+        "",
+    ]
+    for job in jobs:
+        lines += [
+            f"==={job.id}===",
+            f"Priority: {job.priority}",
+            f"Title: {job.title}",
+            "Success criteria:",
+        ]
+        lines += [f"- {criterion}" for criterion in job.success_criteria]
+        lines.append("")
+    lines.append("After the final job, print ===END RUN=== and summarize pass/fail evidence.")
+    return "\n".join(lines)
+
+
+def run_dry(config: ReadinessConfig, run_path: Path, agent: str) -> dict:
+    run_root = run_path / "live" / "runs" / agent
+    run_root.mkdir(parents=True, exist_ok=True)
+    prompt = _prompt_for(config, config.jobs)
+    write_text(run_root / "prompt.txt", prompt + "\n")
+    write_json(
+        run_root / "result.json",
+        {
+            "agent": agent,
+            "mode": "dry-run",
+            "status": "skipped",
+            "jobs_in_scope": [job.id for job in config.jobs],
+            "reason": "dry-run generated the prompt but did not invoke a coding agent",
+        },
+    )
+    rows = [
+        {
+            "id": job.id,
+            "priority": job.priority,
+            "status": "Skipped",
+            "method": "Skipped",
+            "evidence": f"Dry run only; prompt generated at live/runs/{agent}/prompt.txt.",
+        }
+        for job in config.jobs
+    ]
+    payload = {
+        "product_id": config.product_id,
+        "name": config.name,
+        "lane": "headless",
+        "agent": agent,
+        "rows": rows,
+    }
+    write_scorecard(run_path, payload)
+    return payload
+
+
+def write_scorecard(run_path: Path, payload: dict) -> None:
+    write_json(run_path / "scorecard.json", payload)
+    lines = [
+        f"# Scorecard - {payload['name']} x {payload.get('agent', 'agent')}",
+        "",
+        "| ID | Priority | Status | Method | Evidence |",
+        "|---|---|---|---|---|",
+    ]
+    for row in payload["rows"]:
+        lines.append(f"| {row['id']} | {row['priority']} | {row['status']} | {row['method']} | {row['evidence']} |")
+    lines.append("")
+    write_text(run_path / "scorecard.md", "\n".join(lines))
+    write_text(run_path / "journey-report.md", "# Journey Report\n\nDry-run mode generated prompts only.\n")
+    write_text(run_path / "issues.md", "# Issues\n\nNo issues generated in dry-run mode.\n")
+    write_text(run_path / "executive-summary.md", "# Executive Summary\n\nDry-run mode does not produce a release verdict.\n")

--- a/tools/agent-readiness-ci/agent_readiness/optional_lanes.py
+++ b/tools/agent-readiness-ci/agent_readiness/optional_lanes.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .artifacts import write_json, write_text
+from .config import ReadinessConfig
+
+
+def _mode(config: ReadinessConfig, key: str) -> dict:
+    raw = ((config.raw.get("modes") or {}).get(key) or {})
+    return raw if isinstance(raw, dict) else {}
+
+
+def run_remote_placeholder(config: ReadinessConfig, run_path: Path) -> dict:
+    remote_cfg = _mode(config, "remote_deployment")
+    enabled = bool(remote_cfg.get("enabled", False))
+    payload = {
+        "product_id": config.product_id,
+        "lane": "remote",
+        "status": "Skipped" if not enabled else "Blocked",
+        "method": "Remote Live",
+        "reason": "remote_deployment.enabled is false"
+        if not enabled
+        else "remote deployment is enabled but no generic runner adapter has been configured",
+    }
+    write_json(run_path / "remote" / "remote-result.json", payload)
+    write_text(run_path / "remote" / "README.md", payload["reason"] + "\n")
+    return payload
+
+
+def run_hosted_litmus_placeholder(config: ReadinessConfig, run_path: Path) -> dict:
+    litmus_cfg = _mode(config, "litmus_vdr")
+    enabled = bool(litmus_cfg.get("enabled", False))
+    payload = {
+        "product_id": config.product_id,
+        "lane": "hosted-litmus",
+        "status": "Skipped" if not enabled else "Blocked",
+        "method": "Hosted",
+        "reason": "litmus_vdr.enabled is false"
+        if not enabled
+        else "Litmus VDR is enabled but no service URL or MCP adapter has been configured",
+    }
+    write_json(run_path / "hosted" / "litmus-run.json", payload)
+    write_text(run_path / "hosted" / "litmus-report.md", f"# Litmus VDR\n\n{payload['reason']}\n")
+    return payload
+
+
+def run_fvr_placeholder(config: ReadinessConfig, run_path: Path) -> dict:
+    fvr_cfg = _mode(config, "fvr_rc")
+    enabled = bool(fvr_cfg.get("enabled", False))
+    payload = {
+        "product_id": config.product_id,
+        "lane": "fvr-rc",
+        "status": "Skipped" if not enabled else "Blocked",
+        "method": "FVR RC",
+        "reason": "fvr_rc.enabled is false"
+        if not enabled
+        else "FVR RC validation is enabled but no execution adapter has been configured",
+        "native_artifacts": [
+            "00-test-plan.yaml",
+            "01-doc-review.md",
+            "01d-agentic-readiness.md",
+            "02-commands.jsonl",
+            "03-test-results.md",
+            "04-perf-results.md",
+            "05-quality-review.md",
+            "07-grounded-report.md",
+        ],
+    }
+    write_json(run_path / "fvr" / "fvr-summary.json", payload)
+    write_text(run_path / "fvr" / "report.md", f"# FVR RC\n\n{payload['reason']}\n")
+    return payload

--- a/tools/agent-readiness-ci/agent_readiness/publish.py
+++ b/tools/agent-readiness-ci/agent_readiness/publish.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import html
+import shutil
+from pathlib import Path
+
+from .artifacts import read_json
+from .config import ReadinessConfig
+
+
+def publish(config: ReadinessConfig, runs_root: Path, public: Path) -> None:
+    run_path = runs_root / config.product_id / "latest"
+    public.mkdir(parents=True, exist_ok=True)
+    summary = read_json(run_path / "ci-summary.json") if (run_path / "ci-summary.json").exists() else {}
+    static_md = _read_optional(run_path / "static-readiness.md")
+    api_design_md = _read_optional(run_path / "api-design-readiness.md")
+    scorecard_md = _read_optional(run_path / "scorecard.md")
+    status = summary.get("status", "unknown")
+    rate = summary.get("p0_live_pass_rate", "n/a")
+    api_score = summary.get("api_design_score", "n/a")
+    body = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Agent Readiness - {html.escape(config.name)}</title>
+  <style>
+    body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 32px; line-height: 1.45; }}
+    code, pre {{ background: #f5f5f5; padding: 2px 4px; }}
+    pre {{ padding: 16px; overflow: auto; }}
+    .status {{ display: inline-block; padding: 4px 8px; border-radius: 4px; background: #eee; }}
+    table {{ border-collapse: collapse; width: 100%; }}
+    th, td {{ border: 1px solid #ddd; padding: 6px 8px; text-align: left; }}
+  </style>
+</head>
+<body>
+  <h1>Agent Readiness - {html.escape(config.name)}</h1>
+  <p>Status: <strong class="status">{html.escape(str(status))}</strong></p>
+  <p>P0 live pass rate: <strong>{html.escape(str(rate))}</strong></p>
+  <p>API design score: <strong>{html.escape(str(api_score))}</strong></p>
+  <h2>Static Readiness</h2>
+  <pre>{html.escape(static_md)}</pre>
+  <h2>API Design Readiness</h2>
+  <pre>{html.escape(api_design_md)}</pre>
+  <h2>Scorecard</h2>
+  <pre>{html.escape(scorecard_md)}</pre>
+</body>
+</html>
+"""
+    (public / "index.html").write_text(body, encoding="utf-8")
+    if run_path.exists():
+        artifact_dir = public / "artifacts"
+        if artifact_dir.exists():
+            shutil.rmtree(artifact_dir)
+        shutil.copytree(run_path, artifact_dir)
+
+
+def _read_optional(path: Path) -> str:
+    if not path.exists():
+        return "Not generated."
+    return path.read_text(encoding="utf-8")

--- a/tools/agent-readiness-ci/agent_readiness/static_scan.py
+++ b/tools/agent-readiness-ci/agent_readiness/static_scan.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .artifacts import write_json, write_text
+from .config import ReadinessConfig
+
+
+def _exists_any(repo: Path, names: list[str]) -> bool:
+    return any((repo / name).exists() for name in names)
+
+
+def _contains_any(repo: Path, names: list[str], needles: list[str]) -> bool:
+    for name in names:
+        path = repo / name
+        if not path.exists() or not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore").lower()
+        if any(needle.lower() in text for needle in needles):
+            return True
+    return False
+
+
+def _has_code_block(path: Path) -> bool:
+    if not path.exists():
+        return False
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    return "```" in text or "$ " in text or "python " in text or "npm " in text or "pip " in text
+
+
+def _check(status: str, category: str, summary: str, evidence: list[str], recommendation: str) -> dict:
+    severity = "none" if status == "Pass" else ("major" if status == "Fail" else "minor")
+    return {
+        "category": category,
+        "status": status,
+        "method": "Static",
+        "severity": severity,
+        "summary": summary,
+        "evidence": evidence,
+        "recommendation": recommendation,
+    }
+
+
+def scan(config: ReadinessConfig) -> dict:
+    repo = config.repo_path
+    checks: list[dict] = []
+
+    readme = repo / "README.md"
+    has_readme = readme.exists()
+    checks.append(
+        _check(
+            "Pass" if has_readme else "Fail",
+            "readme_first_screen",
+            "README.md is present." if has_readme else "README.md is missing.",
+            ["README.md"] if has_readme else [],
+            "Add a README with product purpose, install, quickstart, and validation commands.",
+        )
+    )
+
+    has_entrypoint = _exists_any(repo, ["AGENTS.md", "CLAUDE.md", "skills.md", ".agents"])
+    checks.append(
+        _check(
+            "Pass" if has_entrypoint else "Fail",
+            "agent_entrypoints",
+            "Agent-facing instructions are present." if has_entrypoint else "No agent-facing entrypoint found.",
+            [name for name in ["AGENTS.md", "CLAUDE.md", "skills.md", ".agents"] if (repo / name).exists()],
+            "Add AGENTS.md or equivalent guidance covering setup, commands, validation, and safety boundaries.",
+        )
+    )
+
+    has_env_docs = _exists_any(repo, [".env.example", "env.example", "requirements.txt", "pyproject.toml", "Dockerfile"])
+    checks.append(
+        _check(
+            "Pass" if has_env_docs else "Partial",
+            "environment_reproducibility",
+            "Environment hints are present." if has_env_docs else "Environment requirements are not explicit.",
+            [name for name in [".env.example", "env.example", "requirements.txt", "pyproject.toml", "Dockerfile"] if (repo / name).exists()],
+            "Declare required env vars, package manager, OS/hardware assumptions, and a clean setup command.",
+        )
+    )
+
+    has_quickstart = has_readme and _has_code_block(readme)
+    has_examples = _exists_any(repo, ["examples", "example", "samples", "sample"])
+    checks.append(
+        _check(
+            "Pass" if has_quickstart and has_examples else "Partial",
+            "examples_quickstarts",
+            "Quickstart commands and examples are present." if has_quickstart and has_examples else "Quickstart or examples are incomplete.",
+            [item for item in ["README.md", "examples/"] if (repo / item).exists() or item == "README.md" and has_quickstart],
+            "Provide a copy-paste hello world, sample input, expected output, and at least one negative/error case.",
+        )
+    )
+
+    has_api_surface = _exists_any(repo, ["openapi.yaml", "openapi.json", "api", "src", "python"]) or _contains_any(
+        repo, ["README.md", "pyproject.toml", "package.json"], ["cli", "api", "[project.scripts]", "entry_points"]
+    )
+    checks.append(
+        _check(
+            "Pass" if has_api_surface else "Partial",
+            "api_cli_surface",
+            "An automatable API/CLI surface is discoverable." if has_api_surface else "No clear automatable API or CLI surface found.",
+            [name for name in ["openapi.yaml", "openapi.json", "api", "src", "python", "pyproject.toml", "package.json"] if (repo / name).exists()],
+            "Document the supported CLI/API/SDK entrypoints with examples and authentication behavior.",
+        )
+    )
+
+    has_troubleshooting = _contains_any(repo, ["README.md", "AGENTS.md", "docs/troubleshooting.md", "TROUBLESHOOTING.md"], ["troubleshoot", "error", "fails", "auth"])
+    checks.append(
+        _check(
+            "Pass" if has_troubleshooting else "Partial",
+            "error_recovery",
+            "Troubleshooting or recovery guidance is present." if has_troubleshooting else "Error recovery guidance is thin.",
+            [name for name in ["docs/troubleshooting.md", "TROUBLESHOOTING.md", "AGENTS.md", "README.md"] if (repo / name).exists()],
+            "Add common failure modes with exact symptoms, likely causes, and next commands.",
+        )
+    )
+
+    return {
+        "product_id": config.product_id,
+        "name": config.name,
+        "lane": "static",
+        "checks": checks,
+        "totals": {
+            "pass": sum(1 for item in checks if item["status"] == "Pass"),
+            "partial": sum(1 for item in checks if item["status"] == "Partial"),
+            "fail": sum(1 for item in checks if item["status"] == "Fail"),
+        },
+    }
+
+
+def write_static_artifacts(run_path: Path, payload: dict) -> None:
+    write_json(run_path / "static-readiness.json", payload)
+    lines = [
+        f"# Static Readiness - {payload['name']}",
+        "",
+        "| Category | Status | Evidence | Recommendation |",
+        "|---|---|---|---|",
+    ]
+    for item in payload["checks"]:
+        evidence = ", ".join(item["evidence"]) if item["evidence"] else "none"
+        lines.append(f"| {item['category']} | {item['status']} | {evidence} | {item['recommendation']} |")
+    lines.append("")
+    write_text(run_path / "static-readiness.md", "\n".join(lines))

--- a/tools/agent-readiness-ci/agent_readiness/summary.py
+++ b/tools/agent-readiness-ci/agent_readiness/summary.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .artifacts import read_json, write_json
+from .config import ReadinessConfig
+
+
+LIVE_METHODS = {"Live", "Remote Live", "Hosted"}
+
+
+def summarize(config: ReadinessConfig, run_path: Path) -> dict:
+    scorecard_path = run_path / "scorecard.json"
+    rows = read_json(scorecard_path).get("rows", []) if scorecard_path.exists() else []
+    p0_rows = [row for row in rows if row.get("priority") == "P0"]
+    p0_live_passes = [
+        row
+        for row in p0_rows
+        if row.get("status") == "Pass" and row.get("method") in LIVE_METHODS
+    ]
+    p0_fails = [row for row in p0_rows if row.get("status") == "Fail"]
+    p0_live_pass_rate = (len(p0_live_passes) / len(p0_rows)) if p0_rows else 0.0
+
+    failures: list[str] = []
+    if p0_live_pass_rate < config.thresholds.p0_live_pass_rate_min:
+        failures.append(
+            f"P0 live pass rate {p0_live_pass_rate:.2f} is below threshold {config.thresholds.p0_live_pass_rate_min:.2f}"
+        )
+    if config.thresholds.fail_on_p0_fail and p0_fails:
+        failures.append(f"{len(p0_fails)} P0 job(s) failed")
+
+    static_path = run_path / "static-readiness.json"
+    static = read_json(static_path) if static_path.exists() else None
+    static_failures = []
+    if static:
+        static_failures = [item for item in static.get("checks", []) if item.get("status") == "Fail"]
+        if static_failures:
+            failures.append(f"{len(static_failures)} static readiness check(s) failed")
+
+    api_design_path = run_path / "api-design-readiness.json"
+    api_design = read_json(api_design_path) if api_design_path.exists() else None
+    api_design_score = None
+    api_design_failures: list[str] = []
+    api_design_blockers: list[str] = []
+    if api_design:
+        api_design_score = float(api_design.get("score", {}).get("ratio", 0.0))
+        api_design_failures = [
+            item["category"]
+            for item in api_design.get("checks", [])
+            if item.get("status") == "Fail"
+        ]
+        api_design_blockers = list(api_design.get("blockers", []))
+        if api_design_score < config.thresholds.api_design_score_min:
+            failures.append(
+                f"API design score {api_design_score:.2f} is below threshold {config.thresholds.api_design_score_min:.2f}"
+            )
+        if config.thresholds.fail_on_unverified_blockers and api_design_blockers:
+            failures.append(f"{len(api_design_blockers)} blocking API design check(s) failed")
+
+    payload = {
+        "product_id": config.product_id,
+        "name": config.name,
+        "status": "passed" if not failures else "failed",
+        "p0_jobs": len(p0_rows),
+        "p0_live_passes": len(p0_live_passes),
+        "p0_live_pass_rate": round(p0_live_pass_rate, 4),
+        "thresholds": {
+            "p0_live_pass_rate_min": config.thresholds.p0_live_pass_rate_min,
+            "api_design_score_min": config.thresholds.api_design_score_min,
+            "fail_on_p0_fail": config.thresholds.fail_on_p0_fail,
+            "fail_on_unverified_blockers": config.thresholds.fail_on_unverified_blockers,
+        },
+        "failures": failures,
+        "static_failures": [item["category"] for item in static_failures],
+        "api_design_score": api_design_score,
+        "api_design_failures": api_design_failures,
+        "api_design_blockers": api_design_blockers,
+    }
+    write_json(run_path / "ci-summary.json", payload)
+    write_junit(run_path, payload)
+    return payload
+
+
+def write_junit(run_path: Path, payload: dict) -> None:
+    failures = payload.get("failures", [])
+    if failures:
+        failure_xml = "\n".join(
+            f'    <failure message="{_xml_escape(item)}">{_xml_escape(item)}</failure>'
+            for item in failures
+        )
+    else:
+        failure_xml = ""
+    text = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        f'<testsuite name="agent-readiness" tests="1" failures="{1 if failures else 0}">\n'
+        f'  <testcase classname="agent-readiness" name="{_xml_escape(payload["product_id"])}">\n'
+        f"{failure_xml}\n"
+        "  </testcase>\n"
+        "</testsuite>\n"
+    )
+    (run_path / "junit.xml").write_text(text, encoding="utf-8")
+
+
+def _xml_escape(value: str) -> str:
+    return (
+        value.replace("&", "&amp;")
+        .replace('"', "&quot;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )

--- a/tools/agent-readiness-ci/pyproject.toml
+++ b/tools/agent-readiness-ci/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "agent-readiness-ci"
+version = "0.1.0"
+description = "Unified CI toolkit for agent-native product readiness checks."
+requires-python = ">=3.9"
+dependencies = ["PyYAML>=6.0"]
+
+[project.scripts]
+agent-readiness = "agent_readiness.cli:main"
+
+[tool.agent-readiness]
+default_config = "agent-readiness.yaml"


### PR DESCRIPTION
Adds a per-PR agent-readiness scan that runs on the omni-ops CPU runner pool and uploads a scorecard artifact on every pull request.

What this adds:
- agent-readiness.yaml: declarative contract for content-agents P0/P1 agent jobs (Material Agent hello-world, BYO USD, service smoke, plus P1 jobs for validation-agent hello-world and missing-key recovery).
- .github/workflows/agent-readiness.yml: PR + workflow_dispatch workflow that runs the static, api-design, and dry-run headless lanes via the bundled toolkit. Observability-only (no --fail-on-threshold). permissions: contents: read.

Safety posture:
- 14 new files, 0 modified, 0 deleted
- Triggers: pull_request + workflow_dispatch only (not push to main)
- No secrets read or written
- Observability-only; cannot block any merge
