### PR TITLE
Retire end-of-life llama-4-maverick references

### DIFF
--- a/.agents/skills/material-agent-cli/references/pipeline-steps.md
+++ b/.agents/skills/material-agent-cli/references/pipeline-steps.md
@@ -271,7 +271,7 @@ steps:
   benchmark:
     enabled: true
     vlm: { backend: nim, model: google/gemma-4-31b-it }
-    llm_judge: { backend: nim, model: meta/llama-4-maverick-17b-128e-instruct }
+    llm_judge: { backend: nim, model: google/gemma-4-31b-it }
     max_workers: 64
 ```
 
@@ -347,7 +347,7 @@ steps:
     enabled: true
     llm_judge:
       backend: nim
-      model: meta/llama-4-maverick-17b-128e-instruct
+      model: google/gemma-4-31b-it
     success_threshold: 4.0
     generate_html_report: true
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ model for release 0.5.
 
 ## Changed
 
+- Retired the end-of-life `meta/llama-4-maverick-17b-128e-instruct` references,
+  including the Material Agent service model list and the `llm_judge` default,
+  replacing them with `google/gemma-4-31b-it`. That model reached end of life
+  on the same date as the Qwen 3.5 models and returns `410 Gone`, so any
+  configuration naming it failed at request time.
 - Restored `google/gemma-4-31b-it` as the public NIM default for VLM and LLM
   workloads across Material, Physics, Joint, Texture, and Validation agents.
 - Aligned shared model helpers, services, collection deployment, examples,

--- a/apps/material_agent/material_agent/config/schema.py
+++ b/apps/material_agent/material_agent/config/schema.py
@@ -293,7 +293,7 @@ def get_step_defaults(step_name: str) -> dict[str, Any]:
             "enabled": False,
             "llm_judge": {
                 "backend": "nim",
-                "model": "meta/llama-4-maverick-17b-128e-instruct",
+                "model": "google/gemma-4-31b-it",
                 "temperature": 0.7,
                 "max_tokens": 1024,
             },

--- a/apps/material_agent_service/service/main.py
+++ b/apps/material_agent_service/service/main.py
@@ -514,11 +514,6 @@ async def get_vlm_models():
             "is_default": True,
         },
         {
-            "value": "nim/meta/llama-4-maverick-17b-128e-instruct",
-            "label": "Llama 4 Maverick 17B",
-            "is_default": False,
-        },
-        {
             "value": "nim/__custom__",
             "label": "NIM (Custom Model)",
             "is_default": False,

--- a/world_understanding/cli.py
+++ b/world_understanding/cli.py
@@ -128,7 +128,7 @@ def _generate_example_input(input_model: Any) -> dict[str, Any]:
             example[field_name] = field_info.get("default", "nim")
 
         elif field_name == "model":
-            example[field_name] = "meta/llama-4-maverick-17b-128e-instruct"
+            example[field_name] = "google/gemma-4-31b-it"
 
         elif field_name == "target_color":
             if "RGB" in description or "color" in description.lower():

--- a/world_understanding/functions/classification/README.md
+++ b/world_understanding/functions/classification/README.md
@@ -22,7 +22,7 @@ Classify a single object using VLM.
 from world_understanding.functions.classification import classify_object
 from world_understanding.functions.models import create_vlm, create_chat_model
 
-vlm = create_vlm(backend="nim", model="meta/llama-4-maverick-17b")
+vlm = create_vlm(backend="nim", model="google/gemma-4-31b-it")
 llm = create_chat_model(service="nim")
 
 result = classify_object(

--- a/world_understanding/functions/classification/__init__.py
+++ b/world_understanding/functions/classification/__init__.py
@@ -14,7 +14,7 @@ Example:
     from world_understanding.functions.classification import classify_object
     from world_understanding.functions.models import create_vlm, create_chat_model
 
-    vlm = create_vlm(backend="nim", model="meta/llama-4-maverick-17b")
+    vlm = create_vlm(backend="nim", model="google/gemma-4-31b-it")
     llm = create_chat_model(backend="nim")
 
     result = classify_object(

--- a/world_understanding/functions/classification/inference.py
+++ b/world_understanding/functions/classification/inference.py
@@ -688,7 +688,7 @@ def classify_object(
         from world_understanding.functions.models.chat_models import create_chat_model
 
         # Create VLM and LLM
-        vlm = create_vlm(backend="nim", model="meta/llama-4-maverick-17b")
+        vlm = create_vlm(backend="nim", model="google/gemma-4-31b-it")
         llm = create_chat_model(backend="nim")
 
         # Classify vehicle type


### PR DESCRIPTION
## Why

`meta/llama-4-maverick-17b-128e-instruct` reached end of life on **2026-07-27** — the same wave that retired the Qwen 3.5 models v0.5.2 addressed — and returns `410 Gone`. The shorter `meta/llama-4-maverick-17b` returns `404`. Both verified by direct request against `https://integrate.api.nvidia.com/v1/chat/completions`.

v0.5.2 was published before this was noticed, so 7 files still reference the retired model.

## Scope

A **configuration cleanup, not a functional break**. The active defaults (`DEFAULT_JUDGE_MODEL`, `DEFAULT_VLM_MODEL`) are already `google/gemma-4-31b-it`; the remaining literal sat under `evaluate`, which is `"enabled": False` by default.

Remaining references were:

- an option in the Material Agent service VLM list
- that disabled-by-default `evaluate.llm_judge`
- the `wu` CLI generated config example
- classification docstrings

## Changes

Both model ids → `google/gemma-4-31b-it`, verified working for text and image requests.

The service VLM list **no longer offers** Llama 4 Maverick. Rewriting the id in place would have left two entries sharing `nim/google/gemma-4-31b-it`, one still labelled `"Llama 4 Maverick 17B"`. A retired model can only return `410`, and selecting a replacement option is a product decision rather than a mechanical substitution, so the entry is removed.

A note is added to the existing v0.5.2 changelog entry.

## Verification

- 3239 passed, 63 skipped, 0 failed across the VLM, model-backend, quickstart-regression, Material Agent, and Material Agent service suites
- `ruff check` and `ruff format --check` pass
- no `meta/llama-4-maverick` references remain outside the changelog entry documenting this change
